### PR TITLE
Fix Yoda Gas Estimation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -77,7 +77,6 @@ github.com/blevesearch/zap/v14 v14.0.0/go.mod h1:sUc/gPGJlFbSQ2ZUh/wGRYwkKx+Dg/5
 github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d/go.mod h1:d3C0AkH6BRcvO8T0UEPu53cnw4IbV63x1bEjildYhO0=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
-github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.21.0-beta h1:At9hIZdJW0s9E/fAz28nrz6AmcNlSVucCH796ZteX1M=
 github.com/btcsuite/btcd v0.21.0-beta/go.mod h1:ZSWyehm27aAuS9bvkATT+Xte3hjHZ+MRgMY/8NJ7K94=
@@ -123,7 +122,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/cosmos-sdk v0.42.2 h1:t2jIxV5DGN1ynOwuSIvQUUHr7tAePN1AG5ArM7o8qos=
 github.com/cosmos/cosmos-sdk v0.42.2/go.mod h1:xiLp1G8mumj82S5KLJGCAyeAlD+7VNomg/aRSJV12yk=
-github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
@@ -740,7 +738,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/sasha-s/go-deadlock v0.2.0 h1:lMqc+fUb7RrFS3gQLtoQsJ7/6TV/pAIFvBsqX73DK8Y=
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa h1:0U2s5loxrTy6/VgfVoLuVLFJcURKLH49ie0zSch7gh4=
 github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
@@ -830,7 +827,6 @@ github.com/tendermint/tendermint v0.34.8 h1:PMWgUx47FrNTsfhxCWzoiIlVAC1SE9+WBlns
 github.com/tendermint/tendermint v0.34.8/go.mod h1:JVuu3V1ZexOaZG8VJMRl8lnfrGw6hEB2TVnoUwKRbss=
 github.com/tendermint/tm-db v0.5.1/go.mod h1:g92zWjHpCYlEvQXvy9M168Su8V1IBEeawpXVVBaK4f4=
 github.com/tendermint/tm-db v0.6.2/go.mod h1:GYtQ67SUvATOcoY8/+x6ylk8Qo02BQyLrAs+yAcLvGI=
-github.com/tendermint/tm-db v0.6.3 h1:ZkhQcKnB8/2jr5EaZwGndN4owkPsGezW2fSisS9zGbg=
 github.com/tendermint/tm-db v0.6.3/go.mod h1:lfA1dL9/Y/Y8wwyPp2NMLyn5P5Ptr/gvDFNWtrCWSf8=
 github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XXQ=
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=

--- a/yoda/execute.go
+++ b/yoda/execute.go
@@ -77,7 +77,7 @@ func signAndBroadcast(
 	return res.TxHash, nil
 }
 
-func SubmitReport(c *Context, l *Logger, keyIndex int64, isKeyUsedFirstTime bool, reports []ReportMsgWithKey) {
+func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWithKey) {
 	// Return key and update pending metric when done with SubmitReport whether successfully or not.
 	defer func() {
 		c.freeKeys <- keyIndex
@@ -111,8 +111,17 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, isKeyUsedFirstTime bool
 	memo := fmt.Sprintf("yoda:%s/exec:%s", version.Version, strings.Join(versions, ","))
 	key := c.keys[keyIndex]
 	// cliCtx := sdkCtx.CLIContext{Client: c.client, TrustNode: true, Codec: cdc}
-	clientCtx := client.Context{Client: c.client, TxConfig: band.MakeEncodingConfig().TxConfig}
-	gasLimit := estimateGas(c, msgs, feeEstimations, !isKeyUsedFirstTime, l)
+	clientCtx := client.Context{
+		Client:            c.client,
+		TxConfig:          band.MakeEncodingConfig().TxConfig,
+		InterfaceRegistry: band.MakeEncodingConfig().InterfaceRegistry,
+	}
+	accountRetriever := authtypes.AccountRetriever{}
+	acc, err := accountRetriever.GetAccount(clientCtx, key.GetAddress())
+	if err != nil {
+		l.Debug(":warning: Failed to query account with error: %s", err.Error())
+	}
+	gasLimit := estimateGas(c, msgs, feeEstimations, acc, l)
 	// We want to resend transaction only if tx returns Out of gas error.
 	for sendAttempt := uint64(1); sendAttempt <= c.maxTry; sendAttempt++ {
 		var txHash string

--- a/yoda/execute.go
+++ b/yoda/execute.go
@@ -112,7 +112,7 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWith
 	key := c.keys[keyIndex]
 	// cliCtx := sdkCtx.CLIContext{Client: c.client, TrustNode: true, Codec: cdc}
 	clientCtx := client.Context{Client: c.client, TxConfig: band.MakeEncodingConfig().TxConfig}
-	gasLimit := estimateGas(c, msgs, feeEstimations)
+	gasLimit := estimateGas(c, msgs, feeEstimations, l)
 	// We want to resend transaction only if tx returns Out of gas error.
 	for sendAttempt := uint64(1); sendAttempt <= c.maxTry; sendAttempt++ {
 		var txHash string

--- a/yoda/execute.go
+++ b/yoda/execute.go
@@ -116,6 +116,7 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWith
 	acc, err := accountRetriever.GetAccount(clientCtx, key.GetAddress())
 	if err != nil {
 		l.Debug(":warning: Failed to query account with error: %s", err.Error())
+		return
 	}
 
 	gasLimit := estimateGas(c, msgs, feeEstimations, acc, l)

--- a/yoda/execute.go
+++ b/yoda/execute.go
@@ -112,7 +112,7 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, isKeyUsedFirstTime bool
 	key := c.keys[keyIndex]
 	// cliCtx := sdkCtx.CLIContext{Client: c.client, TrustNode: true, Codec: cdc}
 	clientCtx := client.Context{Client: c.client, TxConfig: band.MakeEncodingConfig().TxConfig}
-	gasLimit := estimateGas(c, msgs, feeEstimations, isKeyUsedFirstTime, l)
+	gasLimit := estimateGas(c, msgs, feeEstimations, !isKeyUsedFirstTime, l)
 	// We want to resend transaction only if tx returns Out of gas error.
 	for sendAttempt := uint64(1); sendAttempt <= c.maxTry; sendAttempt++ {
 		var txHash string

--- a/yoda/execute.go
+++ b/yoda/execute.go
@@ -112,7 +112,7 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, isKeyUsedFirstTime bool
 	key := c.keys[keyIndex]
 	// cliCtx := sdkCtx.CLIContext{Client: c.client, TrustNode: true, Codec: cdc}
 	clientCtx := client.Context{Client: c.client, TxConfig: band.MakeEncodingConfig().TxConfig}
-	gasLimit := estimateGas(c, msgs, feeEstimations, !isKeyUsedFirstTime, l)
+	gasLimit := estimateGas(c, msgs, feeEstimations, isKeyUsedFirstTime, l)
 	// We want to resend transaction only if tx returns Out of gas error.
 	for sendAttempt := uint64(1); sendAttempt <= c.maxTry; sendAttempt++ {
 		var txHash string

--- a/yoda/execute.go
+++ b/yoda/execute.go
@@ -111,8 +111,17 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWith
 	memo := fmt.Sprintf("yoda:%s/exec:%s", version.Version, strings.Join(versions, ","))
 	key := c.keys[keyIndex]
 	// cliCtx := sdkCtx.CLIContext{Client: c.client, TrustNode: true, Codec: cdc}
-	clientCtx := client.Context{Client: c.client, TxConfig: band.MakeEncodingConfig().TxConfig}
-	gasLimit := estimateGas(c, msgs, feeEstimations, l)
+	clientCtx := client.Context{
+		Client:            c.client,
+		TxConfig:          band.MakeEncodingConfig().TxConfig,
+		InterfaceRegistry: band.MakeEncodingConfig().InterfaceRegistry,
+	}
+	accountRetriever := authtypes.AccountRetriever{}
+	acc, err := accountRetriever.GetAccount(clientCtx, key.GetAddress())
+	if err != nil {
+		l.Debug(":warning: Failed to query account with error: %s", err.Error())
+	}
+	gasLimit := estimateGas(c, msgs, feeEstimations, acc, l)
 	// We want to resend transaction only if tx returns Out of gas error.
 	for sendAttempt := uint64(1); sendAttempt <= c.maxTry; sendAttempt++ {
 		var txHash string

--- a/yoda/gas.go
+++ b/yoda/gas.go
@@ -101,13 +101,13 @@ func estimateReportHandlerGas(msg sdk.Msg, f FeeEstimationData) uint64 {
 	return cost
 }
 
-func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isKeyUsedFirstTime bool) uint64 {
+func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isAccountExistOnChain bool) uint64 {
 	gas := uint64(baseAuthAnteGas)
 
-	if isKeyUsedFirstTime {
-		gas += readAccountWithoutPublicKeyGas + writeAccountGas
-	} else {
+	if isAccountExistOnChain {
 		gas += readAccountGas
+	} else {
+		gas += readAccountWithoutPublicKeyGas + writeAccountGas
 	}
 
 	txByteLength := getTxByteLength(msgs)
@@ -120,8 +120,8 @@ func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isKeyUsedFirstTime b
 	return gas
 }
 
-func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, isKeyUsedFirstTime bool, l *Logger) uint64 {
-	gas := estimateAuthAnteHandlerGas(c, msgs, isKeyUsedFirstTime)
+func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, isAccountExistOnChain bool, l *Logger) uint64 {
+	gas := estimateAuthAnteHandlerGas(c, msgs, isAccountExistOnChain)
 
 	for i := range msgs {
 		gas += estimateReportHandlerGas(msgs[i], feeEstimations[i])

--- a/yoda/gas.go
+++ b/yoda/gas.go
@@ -105,7 +105,7 @@ func estimateReportHandlerGas(msg sdk.Msg, f FeeEstimationData) uint64 {
 func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, acc client.Account) uint64 {
 	gas := uint64(baseAuthAnteGas)
 
-	if acc == nil || acc.GetPubKey() == nil {
+	if acc.GetPubKey() == nil {
 		gas += readAccountWithoutPublicKeyGas + writeAccountGas
 	} else {
 		gas += readAccountGas

--- a/yoda/gas.go
+++ b/yoda/gas.go
@@ -9,21 +9,11 @@ import (
 // Constant used to estimate gas price of reports transaction.
 const (
 	// cosmos
-	baseFixedGas        = uint64(37764)
-	baseTransactionSize = uint64(200)
+	baseFixedGas        = uint64(43245)
+	baseTransactionSize = uint64(253)
 	txCostPerByte       = uint64(5) // Using DefaultTxSizeCostPerByte of BandChain
 
-	readingBaseCost = uint64(1000)
-	writingBaseCost = uint64(2000)
-
-	readingCostPerByte = uint64(3)
-	writingCostPerByte = uint64(30)
-
-	payingFeeCost = uint64(16500)
-
-	// band
-	baseReportCost    = uint64(4024)
-	addingPendingCost = uint64(4500)
+	payingFeeGasCost = uint64(19834)
 
 	baseRequestSize = uint64(32)
 	addressSize     = uint64(20)
@@ -31,7 +21,7 @@ const (
 	baseRawRequestSize = uint64(16)
 )
 
-func estimateTxSize(msgs []sdk.Msg) uint64 {
+func getTxByteLength(msgs []sdk.Msg) uint64 {
 	// base tx + reports
 	size := baseTransactionSize
 
@@ -48,16 +38,7 @@ func estimateTxSize(msgs []sdk.Msg) uint64 {
 	return size
 }
 
-func estimateStoringReportCost(msg sdk.Msg) uint64 {
-	cost := writingBaseCost
-	cost += uint64(len(cdc.MustMarshalBinaryBare(msg))) * writingCostPerByte
-
-	return cost
-}
-
-func estimateReadingRequestCost(f FeeEstimationData) uint64 {
-	cost := readingBaseCost
-
+func getRequestMsgByteLength(f FeeEstimationData) uint64 {
 	size := baseRequestSize
 	size += uint64(len(f.callData))
 	size += uint64(f.askCount) * addressSize
@@ -67,52 +48,52 @@ func estimateReadingRequestCost(f FeeEstimationData) uint64 {
 		size += baseRawRequestSize + uint64(len(r.calldata))
 	}
 
-	cost += size * readingCostPerByte
-
-	return cost
+	return size
 }
 
-func estimateReportHandleCost(msg sdk.Msg, f FeeEstimationData) uint64 {
-	cost := baseReportCost
+func getReportMsgByteLength(msg sdk.Msg) uint64 {
+	return uint64(len(cdc.MustMarshalBinaryBare(msg)))
+}
 
-	// read request twice
-	cost += 2 * estimateReadingRequestCost(f)
+func estimateReportHandlerGas(msg sdk.Msg, f FeeEstimationData) uint64 {
+	reportByteLength := getReportMsgByteLength(msg)
+	requestByteLength := getRequestMsgByteLength(f)
 
-	// write report once
-	cost += estimateStoringReportCost(msg)
+	cost := 6*requestByteLength + 33*reportByteLength + 8041
 
-	// count report
-	countingPerReportCost := 30 + readingCostPerByte*uint64(len(cdc.MustMarshalBinaryBare(msg)))
+	costWhenReachAskCountFirst := 3*reportByteLength*uint64(f.askCount) + 30*uint64(f.askCount)
+	costWhenReachMinCountFirst := 3*reportByteLength*uint64(f.minCount) + 30*uint64(f.minCount) + 7791
 
-	// reach min count and have to update pending list
-	costWhenReacnMinCount := countingPerReportCost*uint64(f.minCount+1) + addingPendingCost
-
-	// reach ask count but don't have to update pending list
-	costWhenReachAskCount := countingPerReportCost * uint64(f.askCount+1)
-
-	if costWhenReacnMinCount > costWhenReachAskCount {
-		cost += costWhenReacnMinCount
+	if costWhenReachMinCountFirst > costWhenReachAskCountFirst {
+		cost += costWhenReachMinCountFirst
 	} else {
-		cost += costWhenReachAskCount
+		cost += costWhenReachAskCountFirst
 	}
 
 	return cost
 }
 
-func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData) uint64 {
-	gas := baseFixedGas
+func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg) uint64 {
+	gas := uint64(baseFixedGas)
 
-	txSize := estimateTxSize(msgs)
-	gas += txCostPerByte * txSize
+	txByteLength := getTxByteLength(msgs)
+	gas += txCostPerByte * txByteLength
 
-	// process paying fee
 	if len(c.gasPrices) > 0 {
-		gas += payingFeeCost
+		gas += payingFeeGasCost
 	}
+
+	return gas
+}
+
+func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, l *Logger) uint64 {
+	gas := estimateAuthAnteHandlerGas(c, msgs)
 
 	for i := range msgs {
-		gas += estimateReportHandleCost(msgs[i], feeEstimations[i])
+		gas += estimateReportHandlerGas(msgs[i], feeEstimations[i])
 	}
+
+	l.Info(":fuel_pump: Estimated gas is %d", gas)
 
 	return gas
 }

--- a/yoda/gas.go
+++ b/yoda/gas.go
@@ -128,7 +128,7 @@ func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData,
 		gas += estimateReportHandlerGas(msgs[i], feeEstimations[i])
 	}
 
-	l.Info(":fuel_pump: Estimated gas is %d", gas)
+	l.Debug(":fuel_pump: Estimated gas is %d", gas)
 
 	return gas
 }

--- a/yoda/gas.go
+++ b/yoda/gas.go
@@ -1,7 +1,6 @@
 package yoda
 
 import (
-	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bandprotocol/chain/x/oracle/types"
@@ -102,13 +101,13 @@ func estimateReportHandlerGas(msg sdk.Msg, f FeeEstimationData) uint64 {
 	return cost
 }
 
-func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, acc client.Account) uint64 {
+func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isAccountExistOnChain bool) uint64 {
 	gas := uint64(baseAuthAnteGas)
 
-	if acc == nil || acc.GetPubKey() == nil {
-		gas += readAccountWithoutPublicKeyGas + writeAccountGas
-	} else {
+	if isAccountExistOnChain {
 		gas += readAccountGas
+	} else {
+		gas += readAccountWithoutPublicKeyGas + writeAccountGas
 	}
 
 	txByteLength := getTxByteLength(msgs)
@@ -121,8 +120,8 @@ func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, acc client.Account) 
 	return gas
 }
 
-func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, acc client.Account, l *Logger) uint64 {
-	gas := estimateAuthAnteHandlerGas(c, msgs, acc)
+func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, isAccountExistOnChain bool, l *Logger) uint64 {
+	gas := estimateAuthAnteHandlerGas(c, msgs, isAccountExistOnChain)
 
 	for i := range msgs {
 		gas += estimateReportHandlerGas(msgs[i], feeEstimations[i])

--- a/yoda/gas.go
+++ b/yoda/gas.go
@@ -101,13 +101,13 @@ func estimateReportHandlerGas(msg sdk.Msg, f FeeEstimationData) uint64 {
 	return cost
 }
 
-func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isAccountExistOnChain bool) uint64 {
+func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isKeyUsedFirstTime bool) uint64 {
 	gas := uint64(baseAuthAnteGas)
 
-	if isAccountExistOnChain {
-		gas += readAccountGas
-	} else {
+	if isKeyUsedFirstTime {
 		gas += readAccountWithoutPublicKeyGas + writeAccountGas
+	} else {
+		gas += readAccountGas
 	}
 
 	txByteLength := getTxByteLength(msgs)
@@ -120,8 +120,8 @@ func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isAccountExistOnChai
 	return gas
 }
 
-func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, isAccountExistOnChain bool, l *Logger) uint64 {
-	gas := estimateAuthAnteHandlerGas(c, msgs, isAccountExistOnChain)
+func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, isKeyUsedFirstTime bool, l *Logger) uint64 {
+	gas := estimateAuthAnteHandlerGas(c, msgs, isKeyUsedFirstTime)
 
 	for i := range msgs {
 		gas += estimateReportHandlerGas(msgs[i], feeEstimations[i])

--- a/yoda/gas.go
+++ b/yoda/gas.go
@@ -1,6 +1,7 @@
 package yoda
 
 import (
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bandprotocol/chain/x/oracle/types"
@@ -101,13 +102,13 @@ func estimateReportHandlerGas(msg sdk.Msg, f FeeEstimationData) uint64 {
 	return cost
 }
 
-func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isAccountExistOnChain bool) uint64 {
+func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, acc client.Account) uint64 {
 	gas := uint64(baseAuthAnteGas)
 
-	if isAccountExistOnChain {
-		gas += readAccountGas
-	} else {
+	if acc == nil || acc.GetPubKey() == nil {
 		gas += readAccountWithoutPublicKeyGas + writeAccountGas
+	} else {
+		gas += readAccountGas
 	}
 
 	txByteLength := getTxByteLength(msgs)
@@ -120,8 +121,8 @@ func estimateAuthAnteHandlerGas(c *Context, msgs []sdk.Msg, isAccountExistOnChai
 	return gas
 }
 
-func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, isAccountExistOnChain bool, l *Logger) uint64 {
-	gas := estimateAuthAnteHandlerGas(c, msgs, isAccountExistOnChain)
+func estimateGas(c *Context, msgs []sdk.Msg, feeEstimations []FeeEstimationData, acc client.Account, l *Logger) uint64 {
+	gas := estimateAuthAnteHandlerGas(c, msgs, acc)
 
 	for i := range msgs {
 		gas += estimateReportHandlerGas(msgs[i], feeEstimations[i])

--- a/yoda/run.go
+++ b/yoda/run.go
@@ -51,15 +51,9 @@ func runImpl(c *Context, l *Logger) error {
 	}
 
 	availiableKeys := make([]bool, len(c.keys))
-	// isKeyUsedFirstTime is used for gas estimation to check
-	// whether account info already stored on chain store.
-	// Account usually be stored on chain when the user send tx
-	// to chain for the first time
-	isKeyUsedFirstTime := make([]bool, len(c.keys))
 	waitingMsgs := make([][]ReportMsgWithKey, len(c.keys))
 	for i := range availiableKeys {
 		availiableKeys[i] = true
-		isKeyUsedFirstTime[i] = true
 		waitingMsgs[i] = []ReportMsgWithKey{}
 	}
 
@@ -87,13 +81,12 @@ func runImpl(c *Context, l *Logger) error {
 		case ev := <-eventChan:
 			go handleTransaction(c, l, ev.Data.(tmtypes.EventDataTx).TxResult)
 		case keyIndex := <-c.freeKeys:
-			isKeyUsedFirstTime[keyIndex] = false
 			if len(waitingMsgs[keyIndex]) != 0 {
 				if uint64(len(waitingMsgs[keyIndex])) > c.maxReport {
-					go SubmitReport(c, l, keyIndex, isKeyUsedFirstTime[keyIndex], waitingMsgs[keyIndex][:c.maxReport])
+					go SubmitReport(c, l, keyIndex, waitingMsgs[keyIndex][:c.maxReport])
 					waitingMsgs[keyIndex] = waitingMsgs[keyIndex][c.maxReport:]
 				} else {
-					go SubmitReport(c, l, keyIndex, isKeyUsedFirstTime[keyIndex], waitingMsgs[keyIndex])
+					go SubmitReport(c, l, keyIndex, waitingMsgs[keyIndex])
 					waitingMsgs[keyIndex] = []ReportMsgWithKey{}
 				}
 			} else {
@@ -103,7 +96,7 @@ func runImpl(c *Context, l *Logger) error {
 			c.updatePendingGauge(1)
 			if availiableKeys[pm.keyIndex] {
 				availiableKeys[pm.keyIndex] = false
-				go SubmitReport(c, l, pm.keyIndex, isKeyUsedFirstTime[pm.keyIndex], []ReportMsgWithKey{pm})
+				go SubmitReport(c, l, pm.keyIndex, []ReportMsgWithKey{pm})
 			} else {
 				waitingMsgs[pm.keyIndex] = append(waitingMsgs[pm.keyIndex], pm)
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Currently, gas estimation for Yoda has been inaccurate since new Cosmos SDK version 0.40.0 due to changes of codec library with some tweaks of data structure occurred in Cosmos SDK.

Therefore, This MR fixes Yoda gas estimation algorithm by going through procedures that are required for submitting `MsgReportData` transaction, and estimate the gas used based on the procedures.

## Implementation details

During analyzing the procedures, we have found that data size of `Account` in `auth` module has been increased due to changing of data structure, which causes `out of gas` when submitting the transaction. And, additional step has been added to a handler of `MsgReportData` which uses `HAS` store operation that cost the gas of 1000.

Therefore, this PR increase gas limit to support higher data size and more operations used by this chain.

All details about gas usage in each procedures can be found in [this link](https://docs.google.com/document/d/1UpYNOETMh3yN5OF4wKrMa9zDh7UfkB89KWOt5GQFFWA/edit?usp=sharing).

Efficiency of gas usage is expected to be more than 85%.

Test results: We have deploy 1 oracle script and 2 data sources that queries gold price in USD per unit. We deployed 1 validator locally. The result is as follow
- Account already stored on chain's store: gas limit is `59282` and gas used is `51817` which is 87% of the gas limit
- No account stored on chain's store: gas limit is `66343` and gas used is `58211` which is 87% of the gas limit

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
