### PR TITLE
Fix app name for `version` package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(LEDGER_ENABLED),true)
 endif
 
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=bandchain \
-	-X github.com/cosmos/cosmos-sdk/version.ServerName=bandd \
+	-X github.com/cosmos/cosmos-sdk/version.AppName=bandd \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags)"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

When typing `bandd version --long`, the server name shows `<appd>` instead of `bandd`.
This is because variable name in `version` package of Cosmos SDK is changed from `ServerName` to `AppName`.

Fixed: #XXXX

## Implementation details

Rename `ServerName` to `AppName` during setting up ldflags.

## Please ensure the following requirements are met before submitting a pull request:

- [ ] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [ ] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
