### PR TITLE
Yoda Fix No-Reuse Account Information

### DIFF
--- a/yoda/execute.go
+++ b/yoda/execute.go
@@ -25,13 +25,17 @@ var (
 )
 
 func signAndBroadcast(
-	c *Context, key keyring.Info, msgs []sdk.Msg, acc client.Account, gasLimit uint64, memo string,
+	c *Context, key keyring.Info, msgs []sdk.Msg, gasLimit uint64, memo string,
 ) (string, error) {
 	clientCtx := client.Context{
 		Client:            c.client,
 		TxConfig:          band.MakeEncodingConfig().TxConfig,
 		BroadcastMode:     "async",
 		InterfaceRegistry: band.MakeEncodingConfig().InterfaceRegistry,
+	}
+	acc, err := queryAccount(clientCtx, key)
+	if err != nil {
+		return "", fmt.Errorf("unable to get account: %w", err)
 	}
 
 	txf := tx.Factory{}.
@@ -70,6 +74,16 @@ func signAndBroadcast(
 	// 	return "", fmt.Errorf("Failed to build tx with error: %s", err.Error())
 	// }
 	return res.TxHash, nil
+}
+
+func queryAccount(clientCtx client.Context, key keyring.Info) (client.Account, error) {
+	accountRetriever := authtypes.AccountRetriever{}
+	acc, err := accountRetriever.GetAccount(clientCtx, key.GetAddress())
+	if err != nil {
+		return nil, err
+	}
+
+	return acc, nil
 }
 
 func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWithKey) {
@@ -111,11 +125,9 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWith
 		TxConfig:          band.MakeEncodingConfig().TxConfig,
 		InterfaceRegistry: band.MakeEncodingConfig().InterfaceRegistry,
 	}
-
-	accountRetriever := authtypes.AccountRetriever{}
-	acc, err := accountRetriever.GetAccount(clientCtx, key.GetAddress())
+	acc, err := queryAccount(clientCtx, key)
 	if err != nil {
-		l.Debug(":warning: Failed to query account with error: %s", err.Error())
+		l.Error(":warning: Failed to query account with error: %s", c, err.Error())
 		return
 	}
 
@@ -126,7 +138,7 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWith
 		l.Info(":e-mail: Sending report transaction attempt: (%d/%d)", sendAttempt, c.maxTry)
 		for broadcastTry := uint64(1); broadcastTry <= c.maxTry; broadcastTry++ {
 			l.Info(":writing_hand: Try to sign and broadcast report transaction(%d/%d)", broadcastTry, c.maxTry)
-			hash, err := signAndBroadcast(c, key, msgs, acc, gasLimit, memo)
+			hash, err := signAndBroadcast(c, key, msgs, gasLimit, memo)
 			if err != nil {
 				// Use info level because this error can happen and retry process can solve this error.
 				l.Info(":warning: %s", err.Error())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fixed: -

The account got from BandChain node has been reused, which should not happen. When there is out-of-gas scenario and trying to do another attempt, same account information has been used. However, sequence number of the account already changed and account information should be updated.

Otherwise, when sending the transaction, it will be rejected during CheckTx, and Yoda is unable to fetch the transaction status from BandChain

## Implementation details

Every time when need account information, it should be always queried from BandChain node without reusing it.

## Please ensure the following requirements are met before submitting a pull request:

- [ ] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [ ] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
