### PR TITLE
Fix ApplyQuery to Remember Return Type

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -498,7 +498,8 @@ func (app *BandApp) Query(req abci.RequestQuery) abci.ResponseQuery {
 		// Since gRPC server unmarshal returning data before sending it back
 		// to client, but remembering data type is handled in baseapp's query method.
 		// so, we need to call this to let it remember return type.
-		// See, baseapp/grpcrouter.go and baseapp/grpcserver.go for more information.
+		// See, baseapp/grpcrouter.go and baseapp/grpcserver.go in Cosmos SDK repository
+		// for more information.
 		app.BaseApp.Query(req)
 		return res
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -493,17 +493,12 @@ func (app *BandApp) Query(req abci.RequestQuery) abci.ResponseQuery {
 		hookReq.Height = app.LastBlockHeight()
 	}
 
-	res, stop := app.hooks.ApplyQuery(req)
-	if stop {
-		// Since gRPC server unmarshal returning data before sending it back
-		// to client, but remembering data type is handled in baseapp's query method.
-		// so, we need to call this to let it remember return type.
-		// See, baseapp/grpcrouter.go and baseapp/grpcserver.go in Cosmos SDK repository
-		// for more information.
-		app.BaseApp.Query(req)
-		return res
+      baseRes := app.BaseApp.Query(req)
+	hookRes, match := app.hooks.ApplyQuery(req)
+	if match {
+		return hookRes
 	}
-
+	return baseRes
 	return app.BaseApp.Query(req)
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -495,6 +495,11 @@ func (app *BandApp) Query(req abci.RequestQuery) abci.ResponseQuery {
 
 	res, stop := app.hooks.ApplyQuery(req)
 	if stop {
+		// Since gRPC server unmarshal returning data before sending it back
+		// to client, but remembering data type is handled in baseapp's query method.
+		// so, we need to call this to let it remember return type.
+		// See, baseapp/grpcrouter.go and baseapp/grpcserver.go for more information.
+		app.BaseApp.Query(req)
 		return res
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -493,13 +493,15 @@ func (app *BandApp) Query(req abci.RequestQuery) abci.ResponseQuery {
 		hookReq.Height = app.LastBlockHeight()
 	}
 
-      baseRes := app.BaseApp.Query(req)
-	hookRes, match := app.hooks.ApplyQuery(req)
+	// Since we have to always run BaseApp.Query() to remember gRPC's return types
+	// (for more information, see Cosmos SDK's baseapp/gorouter.go file),
+	// We run both from baseApp and hooks, then choose the result later.
+	baseRes := app.BaseApp.Query(hookReq)
+	hookRes, match := app.hooks.ApplyQuery(hookReq)
 	if match {
 		return hookRes
 	}
 	return baseRes
-	return app.BaseApp.Query(req)
 }
 
 // LoadHeight loads a particular height


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fixed: -

## Implementation details

Since BaseApp.Query() remember return types of gRPC's methods, before returning result back to the client, using ApplyQuery() without calling `BaseApp.Query()` prevent gRPC server to get return type of the data.

## Please ensure the following requirements are met before submitting a pull request:

- [ ] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [ ] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
