### PR TITLE
(app) Adjust block params on init and migrate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## v2.1.0
 
+- (app) Adjust block params on init and migrate command
 - (bandd) Bump SDK to 0.42.9 to resolve IBC channel restart issue (9800)[https://github.com/cosmos/cosmos-sdk/issues/9800].
+- (yoda) Add retry logic when query data from node
 - (bandd) Parameterized max data report size

--- a/cmd/bandd/cmd/init.go
+++ b/cmd/bandd/cmd/init.go
@@ -173,10 +173,10 @@ func InitCmd(customAppState map[string]json.RawMessage, defaultNodeHome string) 
 			genDoc.Validators = nil
 			genDoc.AppState = appState
 			genDoc.ConsensusParams = types.DefaultConsensusParams()
-			// TODO: Revisit max block size
-			// genDoc.ConsensusParams.Block.MaxBytes = 1000000 // 1M bytes
-			genDoc.ConsensusParams.Block.MaxGas = 40000000 // 40M gas
-			genDoc.ConsensusParams.Block.TimeIotaMs = 1000 // 1 second
+
+			genDoc.ConsensusParams.Block.MaxBytes = 1000000 // 1M bytes
+			genDoc.ConsensusParams.Block.MaxGas = 8000000   // 8M gas
+			genDoc.ConsensusParams.Block.TimeIotaMs = 1000  // 1 second
 			genDoc.ConsensusParams.Validator.PubKeyTypes = []string{types.ABCIPubKeyTypeSecp256k1}
 			if err = genutil.ExportGenesisFile(genDoc, genFile); err != nil {
 				return err

--- a/cmd/bandd/cmd/migrate.go
+++ b/cmd/bandd/cmd/migrate.go
@@ -44,7 +44,7 @@ func GenesisDocFromFile(genDocFile string) (*tmtypes.GenesisDoc, error) {
 	}
 
 	genDoc.ConsensusParams.Block.MaxBytes = 1000000 // 1M bytes
-	genDoc.ConsensusParams.Block.MaxGas = 40000000  // 40M gas
+	genDoc.ConsensusParams.Block.MaxGas = 8000000   // 8M gas
 	genDoc.ConsensusParams.Block.TimeIotaMs = 1000  // 1 second
 
 	if err := genDoc.ValidateAndComplete(); err != nil {


### PR DESCRIPTION
- Set block size to 1M
- Set block gas limit to 8M to prevent tx spamming to slow our chain