### PR TITLE
(yoda) Add retry logic when query data from node

### DIFF
--- a/yoda/run.go
+++ b/yoda/run.go
@@ -22,8 +22,7 @@ import (
 )
 
 const (
-	// TODO: We can subscribe only for txs that contain request messages
-	TxQuery = "tm.event = 'Tx'"
+	TxQuery = "tm.event = 'Tx' AND request.id EXISTS"
 	// EventChannelCapacity is a buffer size of channel between node and this program
 	EventChannelCapacity = 2000
 )

--- a/yoda/run.go
+++ b/yoda/run.go
@@ -33,6 +33,7 @@ func runImpl(c *Context, l *Logger) error {
 	if err != nil {
 		return err
 	}
+	defer c.client.Stop()
 
 	ctx, cxl := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cxl()


### PR DESCRIPTION
## Implementation details
- Add retry logic when query data via ABCIQuery.
- Remove getting account when trying to estimate gas to reduce load to node and make code more simple.
- Filter only request type transactions

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
