### PR TITLE
(yoda) Fix false alarm error when search request id on event log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- (yoda) Change severity of error when query log
 - (bump) Use cosmos-sdk package v0.44.5 / tendermint v0.34.14 / ibc-go v1.1.5
 
 ## [v2.3.2](https://github.com/bandprotocol/chain/releases/tag/v2.3.2)

--- a/yoda/handler.go
+++ b/yoda/handler.go
@@ -47,7 +47,7 @@ func handleTransaction(c *Context, l *Logger, tx abci.TxResult) {
 func handleRequestLog(c *Context, l *Logger, log sdk.ABCIMessageLog) {
 	idStr, err := GetEventValue(log, types.EventTypeRequest, types.AttributeKeyID)
 	if err != nil {
-		l.Debug(":cold_sweat: Failed to parse request id with error: %s", c, err.Error())
+		l.Debug(":cold_sweat: Failed to parse request id with error: %s", err.Error())
 		return
 	}
 

--- a/yoda/handler.go
+++ b/yoda/handler.go
@@ -47,7 +47,7 @@ func handleTransaction(c *Context, l *Logger, tx abci.TxResult) {
 func handleRequestLog(c *Context, l *Logger, log sdk.ABCIMessageLog) {
 	idStr, err := GetEventValue(log, types.EventTypeRequest, types.AttributeKeyID)
 	if err != nil {
-		l.Error(":cold_sweat: Failed to parse request id with error: %s", c, err.Error())
+		l.Debug(":cold_sweat: Failed to parse request id with error: %s", c, err.Error())
 		return
 	}
 


### PR DESCRIPTION
Due to requests from IBC, there are msgs that come with on receive msg that make yoda try to find request id from all message on got error log that cannot find request id.