### PR TITLE
[fix][feed] use blocktime for default timestamp instead of 0

### DIFF
--- a/x/feeds/keeper/grpc_query_test.go
+++ b/x/feeds/keeper/grpc_query_test.go
@@ -69,7 +69,7 @@ func (suite *KeeperTestSuite) TestQueryPrice() {
 			Status:    types.PRICE_STATUS_NOT_IN_CURRENT_FEEDS,
 			SignalID:  "CS:ATOM-USD",
 			Price:     0,
-			Timestamp: 0,
+			Timestamp: suite.ctx.BlockTime().Unix(),
 		},
 	}, res)
 }
@@ -120,7 +120,7 @@ func (suite *KeeperTestSuite) TestQueryPrices() {
 					SignalID:  "CS:NON-EXISTENT",
 					Status:    types.PRICE_STATUS_NOT_IN_CURRENT_FEEDS,
 					Price:     0,
-					Timestamp: 0,
+					Timestamp: suite.ctx.BlockTime().Unix(),
 				},
 			},
 		},
@@ -138,7 +138,12 @@ func (suite *KeeperTestSuite) TestQueryPrices() {
 			signalIDs: []string{"CS:BAND-USD", "CS:NON-EXISTENT"},
 			expectedPrices: []types.Price{
 				prices[0],
-				{SignalID: "CS:NON-EXISTENT", Status: types.PRICE_STATUS_NOT_IN_CURRENT_FEEDS, Price: 0, Timestamp: 0},
+				{
+					SignalID:  "CS:NON-EXISTENT",
+					Status:    types.PRICE_STATUS_NOT_IN_CURRENT_FEEDS,
+					Price:     0,
+					Timestamp: suite.ctx.BlockTime().Unix(),
+				},
 			},
 		},
 		{

--- a/x/feeds/keeper/keeper_price.go
+++ b/x/feeds/keeper/keeper_price.go
@@ -52,7 +52,7 @@ func (k Keeper) GetPrice(ctx sdk.Context, signalID string) types.Price {
 			SignalID:  signalID,
 			Status:    types.PRICE_STATUS_NOT_IN_CURRENT_FEEDS,
 			Price:     0,
-			Timestamp: 0,
+			Timestamp: ctx.BlockTime().Unix(),
 		}
 	}
 

--- a/x/feeds/keeper/keeper_price_test.go
+++ b/x/feeds/keeper/keeper_price_test.go
@@ -66,7 +66,7 @@ func (suite *KeeperTestSuite) TestGetSetDeletePrices() {
 		SignalID:  "CS:ETH-USD",
 		Status:    types.PRICE_STATUS_NOT_IN_CURRENT_FEEDS,
 		Price:     0,
-		Timestamp: 0,
+		Timestamp: suite.ctx.BlockTime().Unix(),
 	})
 	prices = suite.feedsKeeper.GetPrices(ctx, []string{"CS:ATOM-USD", "CS:BAND-USD", "CS:ETH-USD"})
 	suite.Require().Equal(expPrices, prices)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fixed:
- use blocktime as a timestamp for default of price (not in current feeds)

## Implementation details

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
