### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,6 @@ sudo ln -s /opt/homebrew/lib/libgmp.10.dylib /usr/local/lib/
 
 BandChain is licensed under the terms of the GPL 3.0 License unless otherwise specified in the LICENSE file at module's root.
 
-We highly encourage participation from the community to help with D3N development. If you are interested in developing with D3N or have suggestions for protocol improvements, please open an issue, submit a pull request, or [drop as a line].
+We highly encourage participation from the community to help with D3N development. If you are interested in developing with D3N or have suggestions for protocol improvements, please open an issue, submit a pull request, or [drop us a line].
 
 [drop us a line]: mailto:connect@bandprotocol.com

--- a/cylinder/README.md
+++ b/cylinder/README.md
@@ -140,7 +140,7 @@ type Config struct {
 	MaxTry           	uint64        		// The maximum number of tries to submit a report transaction
 	MinDE            	uint64        		// The minimum number of DE
 	GasAdjustStart   	float64       		// The start value of gas adjustment
-	GasAdjustStep    	float64       		// The increment step of gad adjustment
+	GasAdjustStep    	float64       		// The increment step of gas adjustment
 	RandomSecret     	tss.Scalar    		// The secret value that is used for random D,E
 	CheckingDEInterval 	time.Duration  		// The interval for updating DE
 }

--- a/yoda/README.md
+++ b/yoda/README.md
@@ -6,7 +6,7 @@ Yoda is a program that is used by BandChain's validator nodes to automatically f
 
 Since a subset of validators who are selected for a data request must return the data they received from running the specified data source(s), each of them have to send a `MsgReportData` transaction to BandChain in order to fulfill their duty.
 
-Although the transaction can be sent manually by user, it is not convenient, and would be rather time-consuming. Furthermore, most data providers already have APIs that can be used to query data automatically by another software. Therefore, we have developed Yoda to help validators to automatically query data from data providers by executing data source script, then submit the result to fulfill the request.
+Although the transaction can be sent manually by the user, it is not convenient, and would be rather time-consuming. Furthermore, most data providers already have APIs that can be used to query data automatically by another software. Therefore, we have developed Yoda to help validators to automatically query data from data providers by executing data source script, then submit the result to fulfill the request.
 
 For more detail about Yoda, please follows this [link](https://docs.bandchain.org/node-validators/yoda)
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `drop as a line` to `drop us a line`
Corrected `gad` to `gas`
Corrected `by user` to `by the user`

Please review the changes and let me know if any additional changes are needed.