### PR TITLE
feat(filecache): make cache size configurable

### DIFF
--- a/cmd/bandd/cmd/gends.go
+++ b/cmd/bandd/cmd/gends.go
@@ -35,7 +35,7 @@ func AddGenesisDataSourceCmd(defaultNodeHome string) *cobra.Command {
 
 			config.SetRoot(clientCtx.HomeDir)
 
-			f := filecache.New(filepath.Join(defaultNodeHome, "files"))
+			f := filecache.New(filepath.Join(defaultNodeHome, "files"), 0)
 			data, err := os.ReadFile(args[3])
 			if err != nil {
 				return err

--- a/cmd/bandd/cmd/genos.go
+++ b/cmd/bandd/cmd/genos.go
@@ -36,7 +36,8 @@ func AddGenesisOracleScriptCmd(defaultNodeHome string) *cobra.Command {
 			config := serverCtx.Config
 			config.SetRoot(clientCtx.HomeDir)
 
-			f := filecache.New(filepath.Join(defaultNodeHome, "files"))
+			dataDir := filepath.Join(defaultNodeHome, "files")
+			fileCache := filecache.New(dataDir, 0)
 			data, err := os.ReadFile(args[5])
 			if err != nil {
 				return err
@@ -49,7 +50,7 @@ func AddGenesisOracleScriptCmd(defaultNodeHome string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			filename := f.AddFile(compiledData)
+			filename := fileCache.AddFile(compiledData)
 			owner, err := sdk.AccAddressFromBech32(args[4])
 			if err != nil {
 				return err

--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -13,12 +13,16 @@ type Cache struct {
 }
 
 // New creates and returns a new file-backed data caching instance.
-func New(basePath string) Cache {
+// If cacheSizeBytes is 0, it defaults to 32MB.
+func New(basePath string, cacheSizeBytes int64) Cache {
+	if cacheSizeBytes <= 0 {
+		cacheSizeBytes = 32 * 1024 * 1024 // Default to 32MB
+	}
 	return Cache{
 		fileCache: diskv.New(diskv.Options{
 			BasePath:     basePath,
 			Transform:    func(s string) []string { return []string{} },
-			CacheSizeMax: 32 * 1024 * 1024, // 32MB TODO: Make this configurable
+			CacheSizeMax: cacheSizeBytes,
 		}),
 	}
 }

--- a/pkg/filecache/filecache_test.go
+++ b/pkg/filecache/filecache_test.go
@@ -22,7 +22,7 @@ func TestAddFile(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := f.AddFile([]byte("HELLO_WORLD"))
 	require.Equal(t, filename, "6f9b514093848217355d76365df1f54f42bdfd5f4e5f54a654c46b493d162c39")
 
@@ -46,7 +46,7 @@ func TestMustGetFileOK(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := f.AddFile([]byte("BAND"))
 	require.Equal(t, filename, "52f1b54ce34b64a02f9946b29f670a12933152b1122514ea969a91c211aa32fc")
 
@@ -66,7 +66,7 @@ func TestGetFileOK(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := f.AddFile([]byte("BAND"))
 	require.Equal(t, filename, "52f1b54ce34b64a02f9946b29f670a12933152b1122514ea969a91c211aa32fc")
 
@@ -87,7 +87,7 @@ func TestMustGetFileNotExist(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	require.Panics(t, func() {
 		_ = f.MustGetFile("52f1b54ce34b64a02f9946b29f670a12933152b1122514ea969a91c211aa32fc")
 	})
@@ -105,7 +105,7 @@ func TestGetFileNotExist(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	_, err = f.GetFile("52f1b54ce34b64a02f9946b29f670a12933152b1122514ea969a91c211aa32fc")
 	require.Error(t, err)
 }
@@ -122,7 +122,7 @@ func TestMustGetFileGoodContent(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55" // Correct
 	filepath := filepath.Join(dir, filename)
 	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
@@ -144,7 +144,7 @@ func TestGetFileGoodContent(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55" // Correct
 	filepath := filepath.Join(dir, filename)
 	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
@@ -167,7 +167,7 @@ func TestMustGetFileBadContent(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd56" // Not correct
 	filepath := filepath.Join(dir, filename)
 	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
@@ -190,7 +190,7 @@ func TesGetFileBadContent(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd56" // Not correct
 	filepath := filepath.Join(dir, filename)
 	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
@@ -212,7 +212,7 @@ func TestMustGetFileInconsistentContent(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55"
 	filepath := filepath.Join(dir, filename)
 	err = os.WriteFile(filepath, []byte("INCONSISTENT"), 0o600) // Not consistent with name
@@ -234,7 +234,7 @@ func TestGetFileInconsistentContent(t *testing.T) {
 		}
 	}()
 
-	f := filecache.New(dir)
+	f := filecache.New(dir, 0)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55"
 	filepath := filepath.Join(dir, filename)
 	err = os.WriteFile(filepath, []byte("INCONSISTENT"), 0o600) // Not consistent with name


### PR DESCRIPTION
Make the filecache size configurable by adding a cacheSizeBytes parameter to
filecache.New(). This addresses a TODO comment while maintaining backward
compatibility by defaulting to 32MB when 0 is passed.

The change:
- Adds cacheSizeBytes parameter to filecache.New()
- Maintains default 32MB cache size when 0 is passed
- Updates all existing callers to use default size
- Improves documentation

## Please ensure the following requirements are met before submitting a pull request:

- [ ] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [ ] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
