### PR TITLE
Typo fix query.pb.go

### DIFF
--- a/client/grpc/node/query.pb.go
+++ b/client/grpc/node/query.pb.go
@@ -152,7 +152,7 @@ var xxx_messageInfo_EVMValidatorsRequest proto.InternalMessageInfo
 type EVMValidatorsResponse struct {
 	// BlockHeight is the latest block height
 	BlockHeight int64 `protobuf:"varint,1,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
-	// Validators is list of validator's addresss and voting power
+	// Validators is list of validator's address and voting power
 	Validators []ValidatorMinimal `protobuf:"bytes,2,rep,name=validators,proto3" json:"validators"`
 }
 


### PR DESCRIPTION
# Typo Fix in Address

## Description
This pull request corrects the typo "addresss" to "address."

## Changes
- Corrected the spelling of "addresss" to "address."

## Commit Details
- **Commit**: `Fix typo addresss -> address`  
- **Date**: January 22, 2025

## Additional Notes
- Maintainers are allowed to edit this pull request if needed.
- Contributions follow the repository’s security policy.
