### PR TITLE
refactor: unify the error handling methods that are different from the project style

### DIFF
--- a/x/feeds/types/utils.go
+++ b/x/feeds/types/utils.go
@@ -1,6 +1,6 @@
 package types
 
-import "fmt"
+import "errors"
 
 // AbsInt64 returns an absolute of int64.
 // Panics on min int64 (-9223372036854775808).
@@ -15,7 +15,7 @@ func AbsInt64(x int64) int64 {
 // StringToBytes32 converts a string to a fixed size byte array.
 func StringToBytes32(str string) ([32]byte, error) {
 	if len(str) > 32 {
-		return [32]byte{}, fmt.Errorf("string is too long")
+		return [32]byte{}, errors.New("string is too long")
 	}
 
 	var byteArray [32]byte

--- a/x/tss/testutil/util.go
+++ b/x/tss/testutil/util.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"fmt"
+	"errors"
 	"math/rand"
 	"time"
 
@@ -57,7 +57,7 @@ func GenerateSignature(
 	}
 
 	if member.MemberID == 0 {
-		return nil, fmt.Errorf("member not found")
+		return nil, errors.New("member not found")
 	}
 
 	// Compute own private nonce

--- a/yoda/executor/multi.go
+++ b/yoda/executor/multi.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -69,7 +70,7 @@ func (e *MultiExec) Exec(code []byte, arg string, env interface{}) (ExecResult, 
 	errs := []error{}
 	for _, each := range e.nextExecOrder() {
 		res, err := each.Exec(code, arg, env)
-		if err == nil || err == ErrExecutionimeout {
+		if err == nil || errors.Is(err, ErrExecutionimeout) {
 			return res, err
 		} else {
 			errs = append(errs, err)


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.