### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/pkg/filecache/filecache_test.go
+++ b/pkg/filecache/filecache_test.go
@@ -11,16 +11,7 @@ import (
 )
 
 func TestAddFile(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := f.AddFile([]byte("HELLO_WORLD"))
@@ -35,16 +26,7 @@ func TestAddFile(t *testing.T) {
 }
 
 func TestMustGetFileOK(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := f.AddFile([]byte("BAND"))
@@ -55,16 +37,7 @@ func TestMustGetFileOK(t *testing.T) {
 }
 
 func TestGetFileOK(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := f.AddFile([]byte("BAND"))
@@ -76,16 +49,7 @@ func TestGetFileOK(t *testing.T) {
 }
 
 func TestMustGetFileNotExist(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	require.Panics(t, func() {
@@ -94,38 +58,20 @@ func TestMustGetFileNotExist(t *testing.T) {
 }
 
 func TestGetFileNotExist(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
-	_, err = f.GetFile("52f1b54ce34b64a02f9946b29f670a12933152b1122514ea969a91c211aa32fc")
+	_, err := f.GetFile("52f1b54ce34b64a02f9946b29f670a12933152b1122514ea969a91c211aa32fc")
 	require.Error(t, err)
 }
 
 func TestMustGetFileGoodContent(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55" // Correct
 	filepath := filepath.Join(dir, filename)
-	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
+	err := os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
 	require.NoError(t, err)
 
 	content := f.MustGetFile(filename)
@@ -133,21 +79,12 @@ func TestMustGetFileGoodContent(t *testing.T) {
 }
 
 func TestGetFileGoodContent(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55" // Correct
 	filepath := filepath.Join(dir, filename)
-	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
+	err := os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
 	require.NoError(t, err)
 
 	content, err := f.GetFile(filename)
@@ -156,21 +93,12 @@ func TestGetFileGoodContent(t *testing.T) {
 }
 
 func TestMustGetFileBadContent(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd56" // Not correct
 	filepath := filepath.Join(dir, filename)
-	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
+	err := os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
 	require.NoError(t, err)
 
 	require.Panics(t, func() {
@@ -179,21 +107,12 @@ func TestMustGetFileBadContent(t *testing.T) {
 }
 
 func TesGetFileBadContent(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd56" // Not correct
 	filepath := filepath.Join(dir, filename)
-	err = os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
+	err := os.WriteFile(filepath, []byte("NOT_LIKE_THIS"), 0o600)
 	require.NoError(t, err)
 
 	_, err = f.GetFile(filename)
@@ -201,21 +120,12 @@ func TesGetFileBadContent(t *testing.T) {
 }
 
 func TestMustGetFileInconsistentContent(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55"
 	filepath := filepath.Join(dir, filename)
-	err = os.WriteFile(filepath, []byte("INCONSISTENT"), 0o600) // Not consistent with name
+	err := os.WriteFile(filepath, []byte("INCONSISTENT"), 0o600) // Not consistent with name
 	require.NoError(t, err)
 	require.Panics(t, func() {
 		_ = f.MustGetFile(filename)
@@ -223,21 +133,12 @@ func TestMustGetFileInconsistentContent(t *testing.T) {
 }
 
 func TestGetFileInconsistentContent(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filecache")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			panic(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	f := filecache.New(dir)
 	filename := "b20727a9b7cc4198d8785b0ef1fa4c774eb9a360e1563dd4f095ddc7af02bd55"
 	filepath := filepath.Join(dir, filename)
-	err = os.WriteFile(filepath, []byte("INCONSISTENT"), 0o600) // Not consistent with name
+	err := os.WriteFile(filepath, []byte("INCONSISTENT"), 0o600) // Not consistent with name
 	require.NoError(t, err)
 	_, err = f.GetFile(filename)
 	require.Error(t, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.

More info about TempDir  https://pkg.go.dev/testing#B.TempDir

## Implementation details

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
