### PR TITLE
Broken Changelog Release Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v3.0.0](https://github.com/bandprotocol/chain/releases/tag/v3.0.0)
+## [v3.0.0](https://github.com/bandprotocol/chain/releases/tag/v3.0.0-rc2)
 
 * (bump) Use go 1.22.3
 * (bump) Use cosmos-sdk package v0.50.11 / ibc-go v8.5.2


### PR DESCRIPTION
Old link:
[v3.0.0](https://github.com/bandprotocol/chain/releases/tag/v3.0.0)
This link pointed to a non-existent or invalid release tag.

New link:
[v3.0.0](https://github.com/bandprotocol/chain/releases/tag/v3.0.0-rc2)
Updated to point to the correct and existing release candidate tag.