### PR TITLE
Corrected typos

### DIFF
--- a/api/band/oracle/v1/query_grpc.pb.go
+++ b/api/band/oracle/v1/query_grpc.pb.go
@@ -62,7 +62,7 @@ type QueryClient interface {
 	Reporters(ctx context.Context, in *QueryReportersRequest, opts ...grpc.CallOption) (*QueryReportersResponse, error)
 	// ActiveValidators queries all active oracle validators.
 	ActiveValidators(ctx context.Context, in *QueryActiveValidatorsRequest, opts ...grpc.CallOption) (*QueryActiveValidatorsResponse, error)
-	// Params queries parameters used for runnning bandchain network.
+	// Params queries parameters used for running bandchain network.
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
 	// RequestSearch queries the latest request that match search criteria.
 	RequestSearch(ctx context.Context, in *QueryRequestSearchRequest, opts ...grpc.CallOption) (*QueryRequestSearchResponse, error)
@@ -235,7 +235,7 @@ type QueryServer interface {
 	Reporters(context.Context, *QueryReportersRequest) (*QueryReportersResponse, error)
 	// ActiveValidators queries all active oracle validators.
 	ActiveValidators(context.Context, *QueryActiveValidatorsRequest) (*QueryActiveValidatorsResponse, error)
-	// Params queries parameters used for runnning bandchain network.
+	// Params queries parameters used for running bandchain network.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
 	// RequestSearch queries the latest request that match search criteria.
 	RequestSearch(context.Context, *QueryRequestSearchRequest) (*QueryRequestSearchResponse, error)

--- a/app/params/doc.go
+++ b/app/params/doc.go
@@ -3,7 +3,7 @@ Package params defines the simulation parameters in the band.
 
 It contains the default weights used for each transaction used on the module's
 simulation. These weights define the chance for a transaction to be simulated at
-any gived operation.
+any given, gave operation.
 
 You can replace the default values for the weights by providing a params.json
 file with the weights defined for each of the transaction operations:

--- a/cylinder/workers/group/round2.go
+++ b/cylinder/workers/group/round2.go
@@ -129,7 +129,7 @@ func (r *Round2) handleGroup(gid tss.GroupID) {
 		tss.DefaultNonce16Generator{},
 	)
 	if err != nil {
-		logger.Error(":cold_sweat: Failed to genrate encrypted secret shares: %s", err)
+		logger.Error(":cold_sweat: Failed to generate encrypted secret shares: %s", err)
 		return
 	}
 

--- a/cylinder/workers/signing/signing.go
+++ b/cylinder/workers/signing/signing.go
@@ -101,7 +101,7 @@ func (s *Signing) handleSigning(sid tss.SigningID) {
 	}
 
 	// Get private keys of DE
-	privDE, err := s.context.Store.GetDE(types.DE{
+	provide, err := s.context.Store.GetDE(types.DE{
 		PubD: assignedMember.PubD,
 		PubE: assignedMember.PubE,
 	})
@@ -111,7 +111,7 @@ func (s *Signing) handleSigning(sid tss.SigningID) {
 	}
 
 	// Compute own private nonce
-	privNonce, err := tss.ComputeOwnPrivNonce(privDE.PrivD, privDE.PrivE, assignedMember.BindingFactor)
+	privNonce, err := tss.ComputeOwnPrivNonce(provide.PrivD, provide.PrivE, assignedMember.BindingFactor)
 	if err != nil {
 		logger.Error(":cold_sweat: Failed to compute own private nonce: %s", err)
 		return

--- a/x/restake/README.md
+++ b/x/restake/README.md
@@ -274,7 +274,7 @@ This function is used to get the locked power of the account on the vault.
 
 This function is used to set the status of the vault to inactive
 
-**Note:** Once the vault is deactivated, it won’t be able to re-use again.
+**Note:** Once the vault is deactivated, it won’t be able to reuse again.
 
 **Logic**
 


### PR DESCRIPTION
Changes made in:

- /x/restake/README.md ("re-use" → "reuse")

- /app/params/doc.go ("gived" → "given, gave")

- /api/band/oracle/v1/query_grpc.pb.go ("runnning" → "running")

- /api/band/oracle/v1/query_grpc.pb.go ("runnning" → "running")

- /api/band/tunnel/v1beta1/route.pulsar.go ("detination" → "destination")

- /api/band/tunnel/v1beta1/route.pulsar.go ("detination" → "destination")

- /cylinder/workers/signing/signing.go ("privDE" → "provide")

- /cylinder/workers/signing/signing.go ("privDE" → "provide")

- /cylinder/workers/signing/signing.go ("privDE" → "provide")

- /cylinder/workers/group/round2.go ("genrate" → "generate")
