### PR TITLE
[Extra/rest] support events that emitted during initGenesis

### DIFF
--- a/app/hooks.go
+++ b/app/hooks.go
@@ -140,9 +140,10 @@ func splitEvents(events []abci.Event) (begins []abci.Event, ends []abci.Event) {
 		n := len(event.Attributes)
 		attrType := event.Attributes[n-1]
 		if attrType.Key != "mode" {
-			panic("The last attribute of begin/end block event should be mode")
-		}
-		if attrType.Value == "BeginBlock" {
+			// NOTE: There is an event that is emitted when initGenesis (e.g. update_current_feeds)
+			// put it in the begins block for now.
+			begins = append(begins, event)
+		} else if attrType.Value == "BeginBlock" {
 			begins = append(begins, event)
 		} else if attrType.Value == "EndBlock" {
 			ends = append(ends, event)

--- a/hooks/emitter/decoder_test.go
+++ b/hooks/emitter/decoder_test.go
@@ -1178,7 +1178,7 @@ func (suite *DecoderTestSuite) TestDecodeMsgUpdateParams() {
 	}
 
 	emitter.DecodeTSSMsgUpdateParams(&msg, detail)
-	expectedJSON := `{"authority":"band1g96hg6r0wf5hg7gqqqqqqqqqqqqqqqqq4rjgsx","params":{"max_group_size":20,"max_de_size":300,"creation_period":30000,"signing_period":100,"max_signing_attempt":5,"max_memo_length":100,"max_message_length":1000}}`
+	expectedJSON := `{"authority":"band1g96hg6r0wf5hg7gqqqqqqqqqqqqqqqqq4rjgsx","params":{"max_group_size":20,"max_de_size":600,"creation_period":43200,"signing_period":100,"max_signing_attempt":5,"max_memo_length":100,"max_message_length":1000}}`
 	suite.testCompareJson(detail, expectedJSON)
 }
 
@@ -1370,7 +1370,7 @@ func (suite *DecoderTestSuite) TestDecodeTunnelMsgUpdateParams() {
 	emitter.DecodeTunnelMsgUpdateParams(msg, detail)
 	suite.testCompareJson(
 		detail,
-		"{\"authority\":\"band1g96hg6r0wf5hg7gqqqqqqqqqqqqqqqqq4rjgsx\",\"params\":{\"min_deposit\":[{\"denom\":\"uband\",\"amount\":\"1000000000\"}],\"min_interval\":60,\"max_interval\":3600,\"min_deviation_bps\":50,\"max_deviation_bps\":3000,\"max_signals\":25,\"base_packet_fee\":[{\"denom\":\"uband\",\"amount\":\"500\"}],\"axelar_gmp_account\":\"axelar1dv4u5k73pzqrxlzujxg3qp8kvc3pje7jtdvu72npnt5zhq05ejcsn5qme5\"}}",
+		"{\"authority\":\"band1g96hg6r0wf5hg7gqqqqqqqqqqqqqqqqq4rjgsx\",\"params\":{\"min_deposit\":[{\"denom\":\"uband\",\"amount\":\"500000000\"}],\"min_interval\":60,\"max_interval\":86400,\"min_deviation_bps\":50,\"max_deviation_bps\":10000,\"max_signals\":25,\"base_packet_fee\":[{\"denom\":\"uband\",\"amount\":\"100\"}],\"axelar_gmp_account\":\"axelar1dv4u5k73pzqrxlzujxg3qp8kvc3pje7jtdvu72npnt5zhq05ejcsn5qme5\"}}",
 	)
 }
 


### PR DESCRIPTION
Fixed: 
- Events lacking the "mode" key as their final attribute are treated as originating from initGenesis and classified as BeginBlock events.


## Implementation details

## Please ensure the following requirements are met before submitting a pull request:

- [ ] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [ ] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
